### PR TITLE
Update getting started notebook to use OpenAI

### DIFF
--- a/examples/getting_started_agent.ipynb
+++ b/examples/getting_started_agent.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "<a href=\"https://colab.research.google.com/github/run-llama/llamacloud-demo/blob/main/examples/getting_started_agent.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
     "\n",
-    "In this notebook we show you how to build a function calling agent (powered by Claude) over RAG pipelines built with LlamaCloud.\n",
+    "In this notebook we show you how to build a function calling agent (powered by OpenAI) over RAG pipelines built with LlamaCloud.\n",
     "\n",
     "Adding an agentic layer to RAG allows you to build in a layer of query planning and state management that allows you to ask multi-part complex questions over existing RAG pipelines and get back answers in a conversational manner.\n"
    ]
@@ -30,7 +30,7 @@
     "Let's start by importing some simple building blocks.  \n",
     "\n",
     "The main thing we need is:\n",
-    "1. the Anthropic API (using our own `llama_index` LLM class)\n",
+    "1. the OpenAI API (using our own `llama_index` LLM class)\n",
     "2. a place to keep conversation history \n",
     "3. a definition for tools that our agent can use."
    ]
@@ -50,7 +50,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install llama-index-llms-anthropic\n",
     "%pip install llama-index-indices-llama-cloud\n",
     "%pip install llama-index"
    ]
@@ -63,7 +62,9 @@
    "outputs": [],
    "source": [
     "import nest_asyncio\n",
-    "nest_asyncio.apply()"
+    "nest_asyncio.apply()\n",
+    "\n",
+    "from IPython.display import Markdown, display"
    ]
   },
   {
@@ -71,7 +72,7 @@
    "id": "eeac7d4c-58fd-42a5-9da9-c258375c61a0",
    "metadata": {},
    "source": [
-    "Make sure your ANTHROPIC_API_KEY is set. Otherwise explicitly specify the `api_key` parameter."
+    "Make sure your OPENAI_API_KEY is set. Otherwise explicitly specify the `api_key` parameter."
    ]
   },
   {
@@ -81,9 +82,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from llama_index.llms.anthropic import Anthropic\n",
+    "from llama_index.llms.openai import OpenAI\n",
     "\n",
-    "llm = Anthropic(model=\"claude-3-opus-20240229\")"
+    "llm = OpenAI(model=\"gpt-4\")"
    ]
   },
   {
@@ -133,7 +134,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "7c352324-8112-43f1-ad97-d02e581bf282",
    "metadata": {},
    "outputs": [],
@@ -147,14 +148,14 @@
    "id": "cabfdf01-8d63-43ff-b06e-a3059ede2ddf",
    "metadata": {},
    "source": [
-    "## Anthropic Agent over LlamaCloud RAG Pipelines\n",
+    "## OpenAI Agent over LlamaCloud RAG Pipelines\n",
     "\n",
-    "We convert both query engines to tools and pass it to a function calling Anthropic Opus agent."
+    "We convert both query engines to tools and pass it to a function calling OpenAI agent."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "48c0cf98-3f10-4599-8437-d88dc89cefad",
    "metadata": {},
    "outputs": [],
@@ -185,7 +186,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "id": "ebfdaf80-e5e1-4c60-b556-20558da3d5e3",
    "metadata": {},
    "outputs": [],
@@ -201,7 +202,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "id": "58c53f2a-0a3f-4abe-b8b6-97a974ec7546",
    "metadata": {},
    "outputs": [
@@ -210,79 +211,204 @@
      "output_type": "stream",
      "text": [
       "Added user message to memory: Tell me both the tailwinds for Uber and Lyft?\n",
-      "=== LLM Response ===\n",
-      "<thinking>\n",
-      "To answer this question about tailwinds for both Uber and Lyft, I will need to query information from both the uber_10k and lyft_10k tools. The input parameter should be a question asking about tailwinds or positive factors mentioned in the 10-K filings.\n",
-      "</thinking>\n",
       "=== Calling Function ===\n",
-      "Calling function: uber_10k with args: {\"input\": \"What were some of the tailwinds or positive factors mentioned for Uber's business in 2021?\"}\n",
+      "Calling function: uber_10k with args: {\"input\": \"What were the tailwinds for Uber in 2021?\"}\n",
       "=== Function Output ===\n",
-      "Based on the context provided, a few positive factors for Uber's business in 2021 were:\n",
-      "\n",
-      "1. Uber experienced less seasonality in 2021 as a result of the COVID-19 pandemic and related restrictions, which accelerated the growth of Uber's Delivery business as cities imposed various dining restrictions. \n",
-      "\n",
-      "2. Uber's Delivery offering was attracting new consumers to their platform. Over 60% of first-time Delivery consumers in Q4 2021 were new to Uber's platform overall.\n",
-      "\n",
-      "3. Consumers who used both Uber's Mobility and Delivery offerings generated significantly more trips per month on average (12.6) compared to consumers who only used a single offering (5.0) in cities where both were available. This cross-platform usage was beneficial for engagement.\n",
-      "\n",
-      "4. Uber launched Uber One in the U.S. in November 2021, a membership program providing benefits across its rides, delivery and grocery offerings, to make using Uber's suite of products a seamless experience for consumers. Uber exited 2021 with over 6 million members across its various membership programs.\n",
+      "In 2021, Uber experienced several positive factors. The company's revenue increased by $6.3 billion, or 57%, primarily due to a 56% increase in Gross Bookings. This was largely driven by a 71% increase in Delivery Gross Bookings, as a result of increased food delivery orders and higher basket sizes due to stay-at-home orders related to COVID-19. The company also saw growth in Mobility Gross Bookings by 38%, due to increases in Trip volumes as the business recovers from the impacts of COVID-19. Additionally, there was an increase in Delivery revenue resulting from an increase in certain Courier payments and incentives. The growth of Delivery was accelerated in 2021 due to COVID-19 related restrictions. The company also launched new services or expanded existing ones, particularly those related to food and goods delivery, in response to the pandemic.\n",
       "=== Calling Function ===\n",
-      "Calling function: lyft_10k with args: {\"input\": \"What were some of the tailwinds or positive factors mentioned for Lyft's business in 2021?\"}\n",
+      "Calling function: lyft_10k with args: {\"input\": \"What were the tailwinds for Lyft in 2021?\"}\n",
       "=== Function Output ===\n",
-      "Based on the information provided, a few positive factors for Lyft's business in 2021 were:\n",
-      "\n",
-      "1. Lyft continued to invest in the future through organic growth and acquisitions of complementary businesses, even with the impact of COVID-19. This included expanding their network of light vehicles (bikes and scooters) and investing in Lyft Autonomous to deploy and scale third-party self-driving technology.\n",
-      "\n",
-      "2. Lyft believes their brand, values and focus on customer experience are key differentiators. As demand recovers from the pandemic, they are confident more people will choose Lyft for the convenience, experience and affordability. \n",
-      "\n",
-      "3. In the second quarter of 2021, Lyft began generating new revenue streams from licensing and data access agreements, primarily with third-party autonomous vehicle companies.\n",
-      "\n",
-      "4. Lyft launched an autonomous rideshare service in Miami in December 2021 with Ford and Argo AI, delivering on their commitment to deploy autonomous vehicles on the Lyft network.\n",
-      "\n",
-      "So while still impacted by the pandemic in 2021, Lyft saw some positive developments in terms of strategic investments, brand strength, new revenue sources, and progress with autonomous vehicle deployments on their platform.\n",
+      "In 2021, Lyft saw several positive developments. The distribution of vaccines and reopening of communities led to a recovery in demand for their platform. This resulted in a 36% increase in revenue compared to the previous year and a 49.2% increase in the number of Active Riders in the fourth quarter of 2021 compared to the same period in 2020. The company also saw a decrease in net loss by $743.5 million, or 42%, from 2020. Additionally, Lyft completed a transaction with Woven Planet, a subsidiary of Toyota Motor Corporation, which resulted in a pre-tax gain of $119.3 million. The company also achieved its first annual Adjusted EBITDA profitability in 2021.\n",
       "=== LLM Response ===\n",
-      "In summary, some of the key tailwinds mentioned for Uber and Lyft in 2021 were:\n",
+      "In 2021, both Uber and Lyft experienced several tailwinds:\n",
       "\n",
-      "Uber:\n",
-      "- Less seasonality and accelerated growth of Delivery business due to COVID restrictions\n",
-      "- Delivery attracting new consumers to Uber's overall platform \n",
-      "- Higher engagement from consumers using both Mobility and Delivery offerings\n",
-      "- Launch of Uber One membership program\n",
+      "For Uber:\n",
+      "1. The company's revenue increased by $6.3 billion, or 57%, primarily due to a 56% increase in Gross Bookings. \n",
+      "2. There was a 71% increase in Delivery Gross Bookings, as a result of increased food delivery orders and higher basket sizes due to stay-at-home orders related to COVID-19. \n",
+      "3. Uber saw growth in Mobility Gross Bookings by 38%, due to increases in Trip volumes as the business recovers from the impacts of COVID-19. \n",
+      "4. There was an increase in Delivery revenue resulting from an increase in certain Courier payments and incentives. \n",
+      "5. The growth of Delivery was accelerated in 2021 due to COVID-19 related restrictions. \n",
+      "6. The company also launched new services or expanded existing ones, particularly those related to food and goods delivery, in response to the pandemic.\n",
       "\n",
-      "Lyft:\n",
-      "- Continued investment in organic growth and acquisitions despite pandemic impact\n",
-      "- Differentiated brand, values and customer experience \n",
-      "- New revenue streams from licensing and data access agreements\n",
-      "- Launch of autonomous rideshare service in Miami with partners\n",
-      "\n",
-      "Both companies saw some positives despite ongoing pandemic challenges, including growth opportunities, product innovations, and progress on strategic initiatives. The accelerated adoption of delivery services was a particular tailwind for Uber.\n",
-      "assistant: In summary, some of the key tailwinds mentioned for Uber and Lyft in 2021 were:\n",
-      "\n",
-      "Uber:\n",
-      "- Less seasonality and accelerated growth of Delivery business due to COVID restrictions\n",
-      "- Delivery attracting new consumers to Uber's overall platform \n",
-      "- Higher engagement from consumers using both Mobility and Delivery offerings\n",
-      "- Launch of Uber One membership program\n",
-      "\n",
-      "Lyft:\n",
-      "- Continued investment in organic growth and acquisitions despite pandemic impact\n",
-      "- Differentiated brand, values and customer experience \n",
-      "- New revenue streams from licensing and data access agreements\n",
-      "- Launch of autonomous rideshare service in Miami with partners\n",
-      "\n",
-      "Both companies saw some positives despite ongoing pandemic challenges, including growth opportunities, product innovations, and progress on strategic initiatives. The accelerated adoption of delivery services was a particular tailwind for Uber.\n"
+      "For Lyft:\n",
+      "1. The distribution of vaccines and reopening of communities led to a recovery in demand for their platform. \n",
+      "2. This resulted in a 36% increase in revenue compared to the previous year and a 49.2% increase in the number of Active Riders in the fourth quarter of 2021 compared to the same period in 2020. \n",
+      "3. The company saw a decrease in net loss by $743.5 million, or 42%, from 2020. \n",
+      "4. Lyft completed a transaction with Woven Planet, a subsidiary of Toyota Motor Corporation, which resulted in a pre-tax gain of $119.3 million. \n",
+      "5. The company also achieved its first annual Adjusted EBITDA profitability in 2021.\n"
      ]
     }
    ],
    "source": [
-    "response = agent.chat(\"Tell me both the tailwinds for Uber and Lyft?\")\n",
-    "print(str(response))"
+    "response = agent.chat(\"Tell me both the tailwinds for Uber and Lyft?\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "cb682e18-2538-4da7-9bed-5c585d971735",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "In 2021, both Uber and Lyft experienced several tailwinds:\n",
+       "\n",
+       "For Uber:\n",
+       "1. The company's revenue increased by $6.3 billion, or 57%, primarily due to a 56% increase in Gross Bookings. \n",
+       "2. There was a 71% increase in Delivery Gross Bookings, as a result of increased food delivery orders and higher basket sizes due to stay-at-home orders related to COVID-19. \n",
+       "3. Uber saw growth in Mobility Gross Bookings by 38%, due to increases in Trip volumes as the business recovers from the impacts of COVID-19. \n",
+       "4. There was an increase in Delivery revenue resulting from an increase in certain Courier payments and incentives. \n",
+       "5. The growth of Delivery was accelerated in 2021 due to COVID-19 related restrictions. \n",
+       "6. The company also launched new services or expanded existing ones, particularly those related to food and goods delivery, in response to the pandemic.\n",
+       "\n",
+       "For Lyft:\n",
+       "1. The distribution of vaccines and reopening of communities led to a recovery in demand for their platform. \n",
+       "2. This resulted in a 36% increase in revenue compared to the previous year and a 49.2% increase in the number of Active Riders in the fourth quarter of 2021 compared to the same period in 2020. \n",
+       "3. The company saw a decrease in net loss by $743.5 million, or 42%, from 2020. \n",
+       "4. Lyft completed a transaction with Woven Planet, a subsidiary of Toyota Motor Corporation, which resulted in a pre-tax gain of $119.3 million. \n",
+       "5. The company also achieved its first annual Adjusted EBITDA profitability in 2021."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display(Markdown(f\"{response}\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "1b3b5915",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Added user message to memory: What are the investments made by Uber?\n",
+      "=== Calling Function ===\n",
+      "Calling function: uber_10k with args: {\"input\": \"What were the investments made by Uber in 2021?\"}\n",
+      "=== Function Output ===\n",
+      "In 2021, Uber made strategic investments in Grab and Aurora, which became publicly listed within the year. These investments have been classified as marketable equity securities with a readily determinable fair value. Uber also continued to invest in new platform offerings to strengthen their platform and existing offerings.\n",
+      "=== LLM Response ===\n",
+      "In 2021, Uber made the following investments:\n",
+      "\n",
+      "1. Strategic investments in Grab and Aurora, which became publicly listed within the year. These investments have been classified as marketable equity securities with a readily determinable fair value.\n",
+      "2. The company also continued to invest in new platform offerings to strengthen their platform and existing offerings.\n"
+     ]
+    }
+   ],
+   "source": [
+    "response = agent.chat(\"What are the investments made by Uber?\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "305abd8d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "In 2021, Uber made the following investments:\n",
+       "\n",
+       "1. Strategic investments in Grab and Aurora, which became publicly listed within the year. These investments have been classified as marketable equity securities with a readily determinable fair value.\n",
+       "2. The company also continued to invest in new platform offerings to strengthen their platform and existing offerings."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display(Markdown(f\"{response}\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "d45fd026",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Added user message to memory: Compare the investments made by Uber and lyft?\n",
+      "=== Calling Function ===\n",
+      "Calling function: lyft_10k with args: {\"input\": \"What were the investments made by Lyft in 2021?\"}\n",
+      "=== Function Output ===\n",
+      "In 2021, Lyft made several investments. They continued to invest in their mission, including research and development, strategic acquisitions, sales, and marketing. They also invested in the expansion of their network of Light Vehicles and Lyft Autonomous, focusing on the deployment and scaling of third-party self-driving technology. They made payments in excess of $300 million under an amended arrangement with AWS. They also invested in the bikeshare program for the New York metro area, with investments totaling $87.1 million as of December 31, 2021. Additionally, they made payments totaling $23.1 million and investments totaling $23.5 million as part of a noncancelable arrangement with the City of Chicago for the Divvy bike share program. They also continued to invest in their data privacy and security foundation and their intellectual property, holding 343 issued U.S. patents and 310 U.S. patent applications pending as of the end of 2021.\n",
+      "=== LLM Response ===\n",
+      "In 2021, both Uber and Lyft made several investments:\n",
+      "\n",
+      "For Uber:\n",
+      "1. Uber made strategic investments in Grab and Aurora, which became publicly listed within the year. These investments have been classified as marketable equity securities with a readily determinable fair value.\n",
+      "2. The company also continued to invest in new platform offerings to strengthen their platform and existing offerings.\n",
+      "\n",
+      "For Lyft:\n",
+      "1. Lyft continued to invest in their mission, including research and development, strategic acquisitions, sales, and marketing.\n",
+      "2. They invested in the expansion of their network of Light Vehicles and Lyft Autonomous, focusing on the deployment and scaling of third-party self-driving technology.\n",
+      "3. They made payments in excess of $300 million under an amended arrangement with AWS.\n",
+      "4. Lyft invested in the bikeshare program for the New York metro area, with investments totaling $87.1 million as of December 31, 2021.\n",
+      "5. They made payments totaling $23.1 million and investments totaling $23.5 million as part of a noncancelable arrangement with the City of Chicago for the Divvy bike share program.\n",
+      "6. They also continued to invest in their data privacy and security foundation and their intellectual property, holding 343 issued U.S. patents and 310 U.S. patent applications pending as of the end of 2021.\n"
+     ]
+    }
+   ],
+   "source": [
+    "response = agent.chat(\"Compare the investments made by Uber and lyft?\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "69a165e2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "In 2021, both Uber and Lyft made several investments:\n",
+       "\n",
+       "For Uber:\n",
+       "1. Uber made strategic investments in Grab and Aurora, which became publicly listed within the year. These investments have been classified as marketable equity securities with a readily determinable fair value.\n",
+       "2. The company also continued to invest in new platform offerings to strengthen their platform and existing offerings.\n",
+       "\n",
+       "For Lyft:\n",
+       "1. Lyft continued to invest in their mission, including research and development, strategic acquisitions, sales, and marketing.\n",
+       "2. They invested in the expansion of their network of Light Vehicles and Lyft Autonomous, focusing on the deployment and scaling of third-party self-driving technology.\n",
+       "3. They made payments in excess of $300 million under an amended arrangement with AWS.\n",
+       "4. Lyft invested in the bikeshare program for the New York metro area, with investments totaling $87.1 million as of December 31, 2021.\n",
+       "5. They made payments totaling $23.1 million and investments totaling $23.5 million as part of a noncancelable arrangement with the City of Chicago for the Divvy bike share program.\n",
+       "6. They also continued to invest in their data privacy and security foundation and their intellectual property, holding 343 issued U.S. patents and 310 U.S. patent applications pending as of the end of 2021."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display(Markdown(f\"{response}\"))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cb682e18-2538-4da7-9bed-5c585d971735",
+   "id": "ce65a49f",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -290,9 +416,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "llamaindex",
    "language": "python",
-   "name": "python3"
+   "name": "llamaindex"
   },
   "language_info": {
    "codemirror_mode": {
@@ -304,7 +430,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
PR to update the “Getting Started Agent” notebook to use OpenAI instead of Anthropic.

Since we are already asking users to obtain an OpenAI API key while creating an index, requiring them to also obtain an additional API key from Anthropic might create friction. It would be more streamlined to use a single LLM provider for the entire workflow.